### PR TITLE
Fix check for consul no URI string

### DIFF
--- a/src/file2consul.go
+++ b/src/file2consul.go
@@ -259,8 +259,8 @@ func main() {
 		fmt.Println("inDict=", inDict)
 	}
 
-	if serverURIStrFlgChk != "NONE" {
-		fmt.Println("NOTE: Skip save to Consule and update of Cache file because -uri == NONE")
+	if serverURIStrFlgChk == "NONE" {
+		fmt.Println("NOTE: Skip save to Consul and update of Cache file because -uri == NONE")
 	}
 
 	if cacheFiName > "" {


### PR DESCRIPTION
As of now I have info message every time I have URI string set, however the message should be displayed when the string is empty. Thus need to fix it.